### PR TITLE
did some cleaning :)

### DIFF
--- a/expect_test.go
+++ b/expect_test.go
@@ -1,6 +1,9 @@
 package expectate_test
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type MockTestingT struct {
 	FataledWith string
@@ -8,4 +11,25 @@ type MockTestingT struct {
 
 func (t *MockTestingT) Fatal(args ...interface{}) {
 	t.FataledWith = fmt.Sprintln(args...)
+}
+
+type Person struct {
+	Name     string
+	Age      int
+	Job      string
+	Birthday time.Time
+}
+
+var samplePointerToPerson = &Person{
+	Name:     "John Doe",
+	Age:      30,
+	Job:      "Electrician",
+	Birthday: time.Date(1990, time.January, 1, 0, 0, 0, 0, time.UTC),
+}
+
+type ExpectTest struct {
+	name            string
+	subject         interface{}
+	object          interface{}
+	expectedFailure string
 }

--- a/expect_tobe_test.go
+++ b/expect_tobe_test.go
@@ -7,28 +7,7 @@ import (
 	"github.com/gomagedon/expectate"
 )
 
-type Person struct {
-	Name     string
-	Age      int
-	Job      string
-	Birthday time.Time
-}
-
-var myPointerToPerson = &Person{
-	Name:     "John Doe",
-	Age:      30,
-	Job:      "Electrician",
-	Birthday: time.Date(1990, time.January, 1, 0, 0, 0, 0, time.UTC),
-}
-
-type ToBeTest struct {
-	name            string
-	subject         interface{}
-	object          interface{}
-	expectedFailure string
-}
-
-var toBeTests = []ToBeTest{
+var toBeTests = []ExpectTest{
 	{
 		name:            "2 is 2",
 		subject:         2,
@@ -73,45 +52,45 @@ var toBeTests = []ToBeTest{
 	},
 	{
 		name:            "pointer to struct is itself",
-		subject:         myPointerToPerson,
-		object:          myPointerToPerson,
+		subject:         samplePointerToPerson,
+		object:          samplePointerToPerson,
 		expectedFailure: "",
 	},
 	{
-		name:    "pointer to struct is not copy of struct",
-		subject: myPointerToPerson,
-		object: Person{
-			Name:     myPointerToPerson.Name,
-			Age:      myPointerToPerson.Age,
-			Job:      myPointerToPerson.Job,
-			Birthday: myPointerToPerson.Birthday,
-		},
+		name:            "pointer to struct is not copy of struct",
+		subject:         samplePointerToPerson,
+		object:          *samplePointerToPerson,
 		expectedFailure: "&{John Doe 30 Electrician 1990-01-01 00:00:00 +0000 UTC} is not {John Doe 30 Electrician 1990-01-01 00:00:00 +0000 UTC}\n",
 	},
 	{
-		name:    "pointer to struct is not pointer to copy of struct",
-		subject: myPointerToPerson,
-		object: &Person{
-			Name:     myPointerToPerson.Name,
-			Age:      myPointerToPerson.Age,
-			Job:      myPointerToPerson.Job,
-			Birthday: myPointerToPerson.Birthday,
+		name: "pointer to struct is not pointer to copy of struct",
+		subject: &Person{
+			Name:     "Philip Fry",
+			Age:      25,
+			Job:      "Delivery Boy",
+			Birthday: time.Date(1980, time.July, 7, 0, 0, 0, 0, time.UTC),
 		},
-		expectedFailure: "&{John Doe 30 Electrician 1990-01-01 00:00:00 +0000 UTC} is not &{John Doe 30 Electrician 1990-01-01 00:00:00 +0000 UTC}\n",
+		object: &Person{
+			Name:     "Philip Fry",
+			Age:      25,
+			Job:      "Delivery Boy",
+			Birthday: time.Date(1980, time.July, 7, 0, 0, 0, 0, time.UTC),
+		},
+		expectedFailure: "&{Philip Fry 25 Delivery Boy 1980-07-07 00:00:00 +0000 UTC} is not &{Philip Fry 25 Delivery Boy 1980-07-07 00:00:00 +0000 UTC}\n",
 	},
 	{
 		name: "struct is copy of struct",
 		subject: Person{
-			Name:     myPointerToPerson.Name,
-			Age:      myPointerToPerson.Age,
-			Job:      myPointerToPerson.Job,
-			Birthday: myPointerToPerson.Birthday,
+			Name:     "Hermes Conrad",
+			Age:      38,
+			Job:      "Beaurocrat",
+			Birthday: time.Date(2967, time.August, 8, 0, 0, 0, 0, time.UTC),
 		},
 		object: Person{
-			Name:     myPointerToPerson.Name,
-			Age:      myPointerToPerson.Age,
-			Job:      myPointerToPerson.Job,
-			Birthday: myPointerToPerson.Birthday,
+			Name:     "Hermes Conrad",
+			Age:      38,
+			Job:      "Beaurocrat",
+			Birthday: time.Date(2967, time.August, 8, 0, 0, 0, 0, time.UTC),
 		},
 		expectedFailure: "",
 	},

--- a/expect_toequal_test.go
+++ b/expect_toequal_test.go
@@ -2,19 +2,13 @@ package expectate_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gomagedon/expectate"
 	"github.com/google/go-cmp/cmp"
 )
 
-type ToEqualTest struct {
-	name            string
-	subject         interface{}
-	object          interface{}
-	expectedFailure string
-}
-
-var toEqualTests = []ToEqualTest{
+var toEqualTests = []ExpectTest{
 	{
 		name:            "2 equals 2",
 		subject:         2,
@@ -42,16 +36,16 @@ var toEqualTests = []ToEqualTest{
 	{
 		name: "pointer to struct is pointer to copy of struct",
 		subject: &Person{
-			Name:     myPointerToPerson.Name,
-			Age:      myPointerToPerson.Age,
-			Job:      myPointerToPerson.Job,
-			Birthday: myPointerToPerson.Birthday,
+			Name:     "John Doe",
+			Age:      30,
+			Job:      "Electrician",
+			Birthday: time.Date(1990, time.January, 1, 0, 0, 0, 0, time.UTC),
 		},
 		object: &Person{
-			Name:     myPointerToPerson.Name,
-			Age:      myPointerToPerson.Age,
-			Job:      myPointerToPerson.Job,
-			Birthday: myPointerToPerson.Birthday,
+			Name:     "John Doe",
+			Age:      30,
+			Job:      "Electrician",
+			Birthday: time.Date(1990, time.January, 1, 0, 0, 0, 0, time.UTC),
 		},
 		expectedFailure: "",
 	},


### PR DESCRIPTION
Did a little abstracting and cleaning of the test code.

1. Moved `ToBeTest` and `ToEqualTest`, which were identical structs, into `ExpectTest` in expect_test.go instead of their respective specific test files.
2. Renamed `myPointerToPerson` to `samplePointerToPerson` and moved it into expect_test.go as well.
3. Refactored some tests to not be dependent on `samplePointerToPerson` and instead write in the sample struct directly in the table for enhanced readability (and used some fun Futurama references).